### PR TITLE
Repo icon not showing when using in different app

### DIFF
--- a/sidecommunity.json
+++ b/sidecommunity.json
@@ -2,7 +2,7 @@
   "name": "SideStore Team Picks",
   "identifier": "com.sidestoreapps.community",
   "sourceURL": "https://community-apps.sidestore.io/sidecommunity.json",
-  "iconURL": "https://sidestore.io/assets/icon.png",
+  "iconURL": "https://raw.githubusercontent.com/SideStore/SideStore/develop/AltWidget/Assets.xcassets/AltStore.imageset/1024.png",
   "userinfo": {},
   "apps": [
     {

--- a/sidecommunity.json
+++ b/sidecommunity.json
@@ -2,7 +2,7 @@
   "name": "SideStore Team Picks",
   "identifier": "com.sidestoreapps.community",
   "sourceURL": "https://community-apps.sidestore.io/sidecommunity.json",
-  "iconURL": "jsjs",
+  "iconURL": "https://i.imgur.com/JP0Fncv.png",
   "userinfo": {},
   "apps": [
     {

--- a/sidecommunity.json
+++ b/sidecommunity.json
@@ -2,7 +2,7 @@
   "name": "SideStore Team Picks",
   "identifier": "com.sidestoreapps.community",
   "sourceURL": "https://community-apps.sidestore.io/sidecommunity.json",
-  "sourceIconURL": "https://github.com/SideStore/CommunityStore/raw/main/assets/CF187B94-322C-409E-B475-44218E6CBDF7.jpeg",
+  "iconURL": "https://github.com/SideStore/CommunityStore/raw/main/assets/CF187B94-322C-409E-B475-44218E6CBDF7.jpeg",
   "userinfo": {},
   "apps": [
     {

--- a/sidecommunity.json
+++ b/sidecommunity.json
@@ -2,7 +2,7 @@
   "name": "SideStore Team Picks",
   "identifier": "com.sidestoreapps.community",
   "sourceURL": "https://community-apps.sidestore.io/sidecommunity.json",
-  "iconURL": "https://raw.githubusercontent.com/SideStore/SideStore/develop/AltWidget/Assets.xcassets/AltStore.imageset/1024.png",
+  "iconURL": "jsjs",
   "userinfo": {},
   "apps": [
     {

--- a/sidecommunity.json
+++ b/sidecommunity.json
@@ -2,7 +2,7 @@
   "name": "SideStore Team Picks",
   "identifier": "com.sidestoreapps.community",
   "sourceURL": "https://community-apps.sidestore.io/sidecommunity.json",
-  "iconURL": "https://github.com/SideStore/CommunityStore/raw/main/assets/CF187B94-322C-409E-B475-44218E6CBDF7.jpeg",
+  "iconURL": "https://sidestore.io/assets/icon.png",
   "userinfo": {},
   "apps": [
     {


### PR DESCRIPTION
It would show the first apps (ppsspp) icon, now changed to the official Sidestore logo